### PR TITLE
Improve ffmpeg detection and stream packaging

### DIFF
--- a/src/core/FileProcessor.cpp
+++ b/src/core/FileProcessor.cpp
@@ -168,9 +168,38 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
 {
     QStringList args;
 
-    args << "-fflags" << "+genpts";
+    // For raw streams, we need special handling
     if (mediaInfo.isRawStream || !mediaInfo.analyzed) {
+        // Add input format detection for raw streams
+        QString extension = QFileInfo(inputFile).suffix().toLower();
+        QString fileName = QFileInfo(inputFile).fileName().toLower();
+        
+        // Detect codec format
+        if (extension == "bin") {
+            // For .bin files, try to detect codec from filename
+            if (fileName.contains("hevc") || fileName.contains("h265") || fileName.contains("265")) {
+                args << "-f" << "hevc";
+            } else if (fileName.contains("h264") || fileName.contains("avc") || fileName.contains("264")) {
+                args << "-f" << "h264";
+            } else {
+                // Default to HEVC for unknown .bin files (most common in testing)
+                args << "-f" << "hevc";
+            }
+        } else if (extension == "h264" || extension == "264") {
+            args << "-f" << "h264";
+        } else if (extension == "h265" || extension == "265" || extension == "hevc") {
+            args << "-f" << "hevc";
+        }
+        
+        // Check for pixel format hints in filename
+        if (fileName.contains("p010") || fileName.contains("10bit") || fileName.contains("10-bit")) {
+            // For 10-bit content, specify pixel format
+            if (fileName.contains("p010")) {
+                args << "-pix_fmt" << "p010le";
+            }
+        }
 
+        // Add framerate before input file for raw streams
         if (!mediaInfo.frameRate.isEmpty() && !mediaInfo.frameRate.contains("Unknown")) {
             QString frameRate = mediaInfo.frameRate;
             frameRate.remove(" fps").remove("fps");
@@ -178,14 +207,30 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
             double fps = frameRate.toDouble(&ok);
 
             if (ok && fps > 0) {
-                args << "-framerate" << QString::number(fps);
+                args << "-r" << QString::number(fps);
             }
+        }
+        
+        // Extract resolution from filename if available
+        QRegExp resolutionRegex("(\\d{3,4})x(\\d{3,4})");
+        if (fileName.contains(resolutionRegex)) {
+            QString resolution = resolutionRegex.cap(0);
+            args << "-s" << resolution;
         }
     }
 
+    // Always use genpts for better timestamp handling
+    args << "-fflags" << "+genpts";
+    
+    // Input file
     args << "-i" << QDir::toNativeSeparators(inputFile);
 
+    // Copy video codec
     args << "-c:v" << "copy";
+    
+    // Copy all streams (video, audio, subtitles)
+    args << "-c:a" << "copy";
+    args << "-c:s" << "copy";
 
     if (m_overwrite) {
         args << "-y";
@@ -193,11 +238,10 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
 
     if (format.toLower() == "mp4") {
         args << "-f" << "mp4";
-        args << "-movflags" << "faststart";
+        args << "-movflags" << "+faststart";
     } else if (format.toLower() == "mkv") {
         args << "-f" << "matroska";
     }
-
 
     args << QDir::toNativeSeparators(outputFile);
 

--- a/src/core/MediaAnalyzer.cpp
+++ b/src/core/MediaAnalyzer.cpp
@@ -292,8 +292,8 @@ QString MediaAnalyzer::findFFprobeExecutable()
     QString program = "ffprobe";
 #endif
     
-    // Check if ffprobe is available in PATH by running --version
-    process.start(program, QStringList() << "--version");
+    // Check if ffprobe is available in PATH by running -version
+    process.start(program, QStringList() << "-version");
     if (process.waitForStarted(3000) && process.waitForFinished(3000)) {
         if (process.exitCode() == 0) {
             // Parse version output to extract version and year (similar to ffmpeg)

--- a/src/ui/FFmpegSetupDialog.cpp
+++ b/src/ui/FFmpegSetupDialog.cpp
@@ -163,14 +163,14 @@ bool FFmpegSetupDialog::checkFFmpegAvailability(QString &ffmpegPath, QString &ff
 #endif
     
     // Test FFmpeg in PATH
-    ffmpegProcess.start(ffmpegProgram, QStringList() << "--version");
+    ffmpegProcess.start(ffmpegProgram, QStringList() << "-version");
     if (!ffmpegProcess.waitForStarted(3000) || !ffmpegProcess.waitForFinished(3000) || ffmpegProcess.exitCode() != 0) {
         errorMessage = "FFmpeg not found in PATH";
         return false;
     }
     
     // Test FFprobe in PATH
-    ffprobeProcess.start(ffprobeProgram, QStringList() << "--version");
+    ffprobeProcess.start(ffprobeProgram, QStringList() << "-version");
     if (!ffprobeProcess.waitForStarted(3000) || !ffprobeProcess.waitForFinished(3000) || ffprobeProcess.exitCode() != 0) {
         errorMessage = "FFprobe not found in PATH";
         return false;


### PR DESCRIPTION
Correct FFmpeg/FFprobe version check flag and enhance raw stream encapsulation for complete video playback.

The FFmpeg/FFprobe detection failed because the `--version` flag was used instead of the correct `-version`. This PR fixes that, allowing the application to correctly identify installed FFmpeg tools. Additionally, the previous raw stream encapsulation logic (e.g., for `.bin` files) did not properly configure FFmpeg, resulting in output files that only played the first second. The updated logic now automatically detects input codec, pixel format, and resolution from filenames, and ensures all streams are copied, resolving the incomplete playback issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-30044377-2b8c-4156-9783-01119ac83d5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30044377-2b8c-4156-9783-01119ac83d5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

