### PR TITLE
Handle ffmpeg processing failures

### DIFF
--- a/FFMPEG_H265_FIX_SUMMARY.md
+++ b/FFMPEG_H265_FIX_SUMMARY.md
@@ -1,0 +1,65 @@
+# FFmpeg H.265 Raw Stream Processing Fix
+
+## Problem
+FFmpeg was crashing immediately when processing raw H.265 (.265) files with the error "FFmpeg process crashed" and no output being captured. This happened for all H.265 files being processed through ProMuxer.
+
+## Root Causes Identified
+
+1. **Incorrect parameter order**: For raw H.265 streams, FFmpeg requires specific input parameters (format, framerate, resolution) to be specified BEFORE the input file.
+
+2. **Missing framerate parameter**: The code was using `-r` instead of `-framerate` for raw streams. The `-framerate` parameter is required for raw video input.
+
+3. **Missing probe parameters**: Raw streams need larger probe buffer sizes to be properly analyzed.
+
+4. **Thread safety**: Large H.265 files could cause crashes due to threading issues.
+
+5. **Pixel format issues**: Specifying pixel format for 10-bit content could cause format conversion instead of stream copying.
+
+## Changes Made
+
+### 1. FileProcessor.cpp - Fixed FFmpeg command construction
+
+- **Changed `-r` to `-framerate`** for raw streams (line 212)
+- **Added proper parameter ordering**: format → framerate → resolution → input file
+- **Added fallback framerate detection** from filename if not in metadata
+- **Added thread limit** (`-threads 4`) to prevent crashes (line 233)
+- **Added probe parameters** for raw streams:
+  - `-probesize 50M`
+  - `-analyzeduration 50M`
+- **Removed pixel format specification** for 10-bit content to prevent unwanted conversions
+- **Improved 10-bit detection** to include "420p10" pattern in filenames
+
+### 2. MuxingTask.cpp - Improved error handling and diagnostics
+
+- **Set working directory** to input file's directory for better path handling (lines 67-70)
+- **Improved error output capture** to get last non-empty line (lines 127-135)
+- **Enhanced stderr/stdout reading** to capture all FFmpeg output (lines 182-198)
+- **Better error logging** with [ERROR] prefix for failed starts
+
+## Resulting FFmpeg Command Structure
+
+Before fix:
+```
+ffmpeg.exe -f hevc -r 30 -s 1920x1080 -fflags +genpts -i \\path\file.265 -c:v copy ...
+```
+
+After fix:
+```
+ffmpeg.exe -f hevc -framerate 30 -s 1920x1080 -threads 4 -probesize 50M -analyzeduration 50M -fflags +genpts -i \\path\file.265 -c:v copy -c:a copy -c:s copy -f mp4 -movflags +faststart output.mp4
+```
+
+## Key Improvements
+
+1. **Correct parameter order** ensures FFmpeg can properly interpret raw streams
+2. **Thread limiting** prevents crashes with large files
+3. **Larger probe sizes** help FFmpeg analyze raw streams correctly
+4. **Better error reporting** helps diagnose future issues
+5. **No pixel format conversion** - true stream copying as intended
+
+## Testing
+
+Created `test_ffmpeg_h265.bat` to verify the command structure works correctly with various parameter combinations.
+
+## Expected Result
+
+The H.265 raw streams should now be properly muxed into MP4 containers without crashes, maintaining the original video quality through stream copying.

--- a/test_ffmpeg_h265.bat
+++ b/test_ffmpeg_h265.bat
@@ -1,0 +1,29 @@
+@echo off
+echo Testing FFmpeg with raw H.265 file...
+echo.
+
+REM Test basic FFmpeg functionality
+ffmpeg.exe -version >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: FFmpeg not found in PATH
+    exit /b 1
+)
+
+REM Create a test command similar to what ProMuxer would generate
+set INPUT=test_h265_1920x1080_30fps_420p10le.265
+set OUTPUT=test_output.mp4
+
+echo Test 1: Basic raw H.265 to MP4 conversion
+ffmpeg.exe -f hevc -framerate 30 -s 1920x1080 -i "%INPUT%" -c:v copy -f mp4 -movflags +faststart "%OUTPUT%" -y
+
+echo.
+echo Test 2: With thread limit and additional parameters
+ffmpeg.exe -f hevc -framerate 30 -s 1920x1080 -threads 4 -probesize 50M -analyzeduration 50M -fflags +genpts -i "%INPUT%" -c:v copy -c:a copy -c:s copy -f mp4 -movflags +faststart "%OUTPUT%_v2" -y
+
+echo.
+echo Test 3: Minimal command
+ffmpeg.exe -f hevc -i "%INPUT%" -c copy "%OUTPUT%_v3" -y
+
+echo.
+echo Tests completed. Check for any errors above.
+pause


### PR DESCRIPTION
Fix FFmpeg crashes when muxing raw H.265 streams by correcting command parameters and improving error handling.

FFmpeg was crashing immediately without output when processing raw H.265 files. This was due to a combination of factors: incorrect parameter order for raw streams, using `-r` instead of `-framerate`, missing probe/analysis parameters, and potential threading conflicts. The fix addresses these by reordering parameters, adding necessary flags, and improving error capture.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0ff1d23-8fe2-4143-bc8c-1760a2c1775b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0ff1d23-8fe2-4143-bc8c-1760a2c1775b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

