### PR TITLE
Improve ffmpeg detection and stream packaging

### DIFF
--- a/src/core/FileProcessor.cpp
+++ b/src/core/FileProcessor.cpp
@@ -169,23 +169,90 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
     QStringList args;
 
     args << "-fflags" << "+genpts";
-    if (mediaInfo.isRawStream || !mediaInfo.analyzed) {
 
-        if (!mediaInfo.frameRate.isEmpty() && !mediaInfo.frameRate.contains("Unknown")) {
-            QString frameRate = mediaInfo.frameRate;
-            frameRate.remove(" fps").remove("fps");
-            bool ok;
-            double fps = frameRate.toDouble(&ok);
+    // Determine if this is a raw elementary stream (e.g., .h264/.h265/.bin)
+    QString extension = QFileInfo(inputFile).suffix().toLower();
+    bool looksRawByExt = QStringList({"h264", "h265", "hevc", "bin", "264", "265"}).contains(extension);
+    bool isRaw = mediaInfo.isRawStream || looksRawByExt;
 
-            if (ok && fps > 0) {
-                args << "-framerate" << QString::number(fps);
+    // Heuristically determine codec for raw streams
+    auto determineIsHevc = [&]() -> bool {
+        QString codec = mediaInfo.videoCodec.toLower();
+        QString name = QFileInfo(inputFile).fileName().toLower();
+        if (codec.contains("265") || codec.contains("hevc")) return true;
+        if (codec.contains("264") || codec.contains("h264") || codec.contains("avc")) return false;
+        if (name.contains("hevc") || name.contains("h265") || extension == "265" || extension == "hevc") return true;
+        if (name.contains("h264") || name.contains("avc") || extension == "264" || extension == "h264") return false;
+        // Default to HEVC for unknown .bin if filename hints at it, otherwise assume H.264
+        return name.contains("hevc") || name.contains("265");
+    };
+
+    if (isRaw) {
+        // Set input frame rate for raw streams using -r (input option)
+        if (!mediaInfo.frameRate.isEmpty() && !mediaInfo.frameRate.contains("Unknown", Qt::CaseInsensitive)) {
+            QString frameRateText = mediaInfo.frameRate;
+            frameRateText.remove(" fps").remove("fps");
+            bool ok = false;
+            double fps = frameRateText.toDouble(&ok);
+            if (ok && fps > 0.0) {
+                args << "-r" << QString::number(fps);
             }
         }
+
+        // Explicitly set demuxer for raw elementary streams
+        bool hevc = determineIsHevc();
+        args << "-f" << (hevc ? "hevc" : "h264");
     }
 
+    // Input file must come after any input options (-r, -f, etc.)
     args << "-i" << QDir::toNativeSeparators(inputFile);
 
+    // Stream copy only (no re-encoding)
     args << "-c:v" << "copy";
+
+    // Preserve color metadata when provided
+    QString cs = mediaInfo.colorSpace.toLower();
+    bool hasColorInfo = !mediaInfo.colorSpace.isEmpty() && !cs.contains("unknown", Qt::CaseInsensitive);
+    if (hasColorInfo) {
+        // Container-level color tags (visible to many players)
+        if (cs.contains("2020")) {
+            args << "-color_primaries" << "bt2020"
+                 << "-colorspace" << "bt2020nc"
+                 << "-color_trc" << "smpte2084";
+        } else if (cs.contains("709")) {
+            args << "-color_primaries" << "bt709"
+                 << "-colorspace" << "bt709"
+                 << "-color_trc" << "bt709";
+        } else if (cs.contains("601") || cs.contains("smpte 170m") || cs.contains("smpte")) {
+            args << "-color_primaries" << "smpte170m"
+                 << "-colorspace" << "smpte170m"
+                 << "-color_trc" << "smpte170m";
+        }
+
+        // Bitstream-level color metadata injection via bsf (retains c:v copy)
+        QString bsf;
+        if (isRaw) {
+            bool hevc = determineIsHevc();
+            QString primaries, trc, matrix;
+            if (cs.contains("2020")) {
+                primaries = "bt2020"; trc = "smpte2084"; matrix = "bt2020nc";
+            } else if (cs.contains("709")) {
+                primaries = "bt709"; trc = "bt709"; matrix = "bt709";
+            } else {
+                primaries = "smpte170m"; trc = "smpte170m"; matrix = "smpte170m";
+            }
+            if (hevc) {
+                bsf = QString("hevc_metadata=color_primaries=%1:transfer_characteristics=%2:matrix_coefficients=%3")
+                          .arg(primaries, trc, matrix);
+            } else {
+                bsf = QString("h264_metadata=color_primaries=%1:transfer_characteristics=%2:matrix_coefficients=%3")
+                          .arg(primaries, trc, matrix);
+            }
+        }
+        if (!bsf.isEmpty()) {
+            args << "-bsf:v" << bsf;
+        }
+    }
 
     if (m_overwrite) {
         args << "-y";
@@ -194,6 +261,16 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
     if (format.toLower() == "mp4") {
         args << "-f" << "mp4";
         args << "-movflags" << "faststart";
+
+        // Improve compatibility for H.264/HEVC in MP4
+        if (isRaw) {
+            bool hevc = determineIsHevc();
+            if (hevc) {
+                args << "-tag:v" << "hvc1";
+            } else {
+                args << "-tag:v" << "avc1";
+            }
+        }
     } else if (format.toLower() == "mkv") {
         args << "-f" << "matroska";
     }
@@ -207,22 +284,33 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
 QString FileProcessor::findFFmpegExecutable()
 {
     QProcess process;
-    
-    QString program = "ffmpeg.exe";
 
-    
-    // Check if ffmpeg is available in PATH by running -version
-    process.start(program, QStringList() << "-version");
-    if (process.waitForStarted(3000) && process.waitForFinished(8000)) {
-        if (process.exitCode() == 0) {
-            // Parse version output to extract version and year
-            QString output = QString::fromUtf8(process.readAllStandardOutput());
+    // Prefer explicit environment variable if provided
+    QString envPath = qEnvironmentVariable("FFMPEG_PATH");
+    if (!envPath.isEmpty()) {
+        process.start(envPath, QStringList() << "-version");
+        if (process.waitForStarted(3000) && process.waitForFinished(8000) && process.exitCode() == 0) {
+            QString output = QString::fromUtf8(process.readAllStandardOutput() + process.readAllStandardError());
             parseAndLogFFmpegVersion(output);
-            return program;
+            return envPath;
         }
     }
-    
-    return QString(); // Not found in PATH
+
+#ifdef Q_OS_WIN
+    QString program = "ffmpeg.exe";
+#else
+    QString program = "ffmpeg";
+#endif
+
+    // Check if ffmpeg is available in PATH by running -version
+    process.start(program, QStringList() << "-version");
+    if (process.waitForStarted(3000) && process.waitForFinished(8000) && process.exitCode() == 0) {
+        QString output = QString::fromUtf8(process.readAllStandardOutput() + process.readAllStandardError());
+        parseAndLogFFmpegVersion(output);
+        return program;
+    }
+
+    return QString(); // Not found
 }
 
 void FileProcessor::parseAndLogFFmpegVersion(const QString &versionOutput)
@@ -248,7 +336,9 @@ void FileProcessor::parseAndLogFFmpegVersion(const QString &versionOutput)
     
     // Extract copyright year range
     QRegularExpression yearRegex(R"(Copyright \(c\) (\d{4})-(\d{4}))");
-    QRegularExpressionMatch yearMatch = yearRegex.match(firstLine);
+    // Search across all lines, not just the first
+    QString joined = versionOutput;
+    QRegularExpressionMatch yearMatch = yearRegex.match(joined);
     QString yearRange = "Unknown";
     if (yearMatch.hasMatch()) {
         QString startYear = yearMatch.captured(1);

--- a/src/ui/FFmpegSetupDialog.cpp
+++ b/src/ui/FFmpegSetupDialog.cpp
@@ -154,24 +154,28 @@ bool FFmpegSetupDialog::checkFFmpegAvailability(QString &ffmpegPath, QString &ff
 {
     QProcess ffmpegProcess, ffprobeProcess;
     
+    // Prefer environment overrides
+    QString ffmpegProgram = qEnvironmentVariable("FFMPEG_PATH");
+    QString ffprobeProgram = qEnvironmentVariable("FFPROBE_PATH");
+
 #ifdef Q_OS_WIN
-    QString ffmpegProgram = "ffmpeg.exe";
-    QString ffprobeProgram = "ffprobe.exe";
+    if (ffmpegProgram.isEmpty()) ffmpegProgram = "ffmpeg.exe";
+    if (ffprobeProgram.isEmpty()) ffprobeProgram = "ffprobe.exe";
 #else
-    QString ffmpegProgram = "ffmpeg";
-    QString ffprobeProgram = "ffprobe";
+    if (ffmpegProgram.isEmpty()) ffmpegProgram = "ffmpeg";
+    if (ffprobeProgram.isEmpty()) ffprobeProgram = "ffprobe";
 #endif
     
-    // Test FFmpeg in PATH
-    ffmpegProcess.start(ffmpegProgram, QStringList() << "--version");
-    if (!ffmpegProcess.waitForStarted(3000) || !ffmpegProcess.waitForFinished(3000) || ffmpegProcess.exitCode() != 0) {
+    // Test FFmpeg in PATH or specified location
+    ffmpegProcess.start(ffmpegProgram, QStringList() << "-version");
+    if (!ffmpegProcess.waitForStarted(3000) || !ffmpegProcess.waitForFinished(8000) || ffmpegProcess.exitCode() != 0) {
         errorMessage = "FFmpeg not found in PATH";
         return false;
     }
     
-    // Test FFprobe in PATH
-    ffprobeProcess.start(ffprobeProgram, QStringList() << "--version");
-    if (!ffprobeProcess.waitForStarted(3000) || !ffprobeProcess.waitForFinished(3000) || ffprobeProcess.exitCode() != 0) {
+    // Test FFprobe in PATH or specified location
+    ffprobeProcess.start(ffprobeProgram, QStringList() << "-version");
+    if (!ffprobeProcess.waitForStarted(3000) || !ffprobeProcess.waitForFinished(8000) || ffprobeProcess.exitCode() != 0) {
         errorMessage = "FFprobe not found in PATH";
         return false;
     }

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -87,6 +87,7 @@ private slots:
     
     // Environment setup
     void checkFFmpegEnvironment();
+    void logFFmpegEnvironmentDetails();
 
 private:
     void setupConnections();


### PR DESCRIPTION
Improve FFmpeg/FFprobe detection robustness and fix raw stream muxing to correctly handle frame rates and metadata.

The original FFmpeg detection logic sometimes failed to find executables even when they were in the PATH or accessible via `ffmpeg -version`. This PR enhances it to check environment variables (`FFMPEG_PATH`, `FFPROBE_PATH`) and provides clearer version logging. For raw `.bin` video streams, the previous muxing command often resulted in truncated videos (e.g., 1 second duration) and incorrect frame rates. This fix explicitly sets the input demuxer (`-f h264/hevc`), uses input-side frame rate (`-r`), and injects bitstream color metadata, ensuring full duration and correct playback without re-encoding.

---
<a href="https://cursor.com/background-agent?bcId=bc-2136853a-c7bd-4477-80d8-7d1f2606ca29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2136853a-c7bd-4477-80d8-7d1f2606ca29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

