### PR TITLE
Fix AV1 film grain and output format issues

### DIFF
--- a/src/core/FileProcessor.cpp
+++ b/src/core/FileProcessor.cpp
@@ -244,8 +244,9 @@ QStringList FileProcessor::buildFFmpegCommand(const QString &inputFile, const QS
     if (enableFilmGrain && isAv1) {
         // Re-encode with libsvtav1 and apply film grain synthesis
         args << "-c:v" << "libsvtav1";
-        args << "-crf" << "30"; // reasonable default
-        args << "-preset" << "6";
+        // Align with defect requirement: CRF 20, preset 4 for better quality
+        args << "-crf" << "20";
+        args << "-preset" << "4";
         args << "-b:v" << "0";
         // Set pixel format based on bit depth
         QString pixelFormat = parsePixelFormat(mediaInfo);

--- a/src/core/MediaAnalyzer.h
+++ b/src/core/MediaAnalyzer.h
@@ -50,6 +50,9 @@ private:
     MediaInfo createDefaultMediaInfo(const QString &filePath);
     QString getResolutionDescription(int width, int height);
     void parseAndLogFFprobeVersion(const QString &versionOutput);
+    QString normalizeFpsFromText(const QString &text);
+    QString extractFpsFromName(const QString &name);
+    QString bitDepthFromPixelFormat(const QString &pixFmt);
     
     QProcess *m_probeProcess;
     QQueue<AnalysisTask> m_taskQueue;

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -210,7 +210,8 @@ void MainWindow::dropEvent(QDropEvent *event)
                 QStringList filters;
                 filters << "*.mp4" << "*.mkv" << "*.avi" << "*.mov" << "*.wmv" 
                        << "*.flv" << "*.webm" << "*.m4v" << "*.3gp" << "*.ts"
-                       << "*.h264" << "*.h265" << "*.bin" << "*.264" << "*.265";
+                       << "*.h264" << "*.h265" << "*.bin" << "*.264" << "*.265"
+                       << "*.hevc"  << "*.26l" << "*.ivf";
                 QFileInfoList fileInfos = dir.entryInfoList(filters, QDir::Files);
                 foreach (const QFileInfo &fileInfo, fileInfos) {
                     files << fileInfo.absoluteFilePath();
@@ -264,7 +265,8 @@ void MainWindow::addFolder()
         QStringList filters;
         filters << "*.mp4" << "*.mkv" << "*.avi" << "*.mov" << "*.wmv" 
                << "*.flv" << "*.webm" << "*.m4v" << "*.3gp" << "*.ts"
-               << "*.h264" << "*.h265" << "*.bin" << "*.264" << "*.265";
+               << "*.h264" << "*.h265" << "*.bin" << "*.264" << "*.265"
+               << "*.hevc"  << "*.26l" << "*.ivf";
         
         QFileInfoList fileInfos = dir.entryInfoList(filters, QDir::Files | QDir::NoDotAndDotDot, QDir::Name);
         QStringList files;
@@ -839,7 +841,7 @@ bool MainWindow::isVideoFile(const QString &filePath)
     QStringList videoExtensions;
     videoExtensions << "mp4" << "mkv" << "avi" << "mov" << "wmv" << "flv" 
                    << "webm" << "m4v" << "3gp" << "ts" << "h264" << "h265" 
-                   << "bin" << "264" << "265";
+                   << "bin" << "264" << "265"  << "*.hevc"  << "*.26l" << "*.ivf";
     
     QString extension = QFileInfo(filePath).suffix().toLower();
     return videoExtensions.contains(extension);

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -468,6 +468,9 @@ void MainWindow::startProcessing()
     // Determine processing mode
     QString processingMode = ui->binToYuvModeRadio->isChecked() ? "binToYuv" : "muxing";
     
+    // Persist current UI settings so downstream components (FileProcessor) can read them
+    saveSettings();
+
     logMessage("Starting batch processing...", LogLevel::Info);
     // Mark all rows as queued before starting
     for (int i = 0; i < ui->fileTable->rowCount(); ++i) {
@@ -580,6 +583,10 @@ void MainWindow::onMediaAnalysisFinished(int index, const MediaInfo &info)
             setupEditableCell(index, COL_BIT_DEPTH, info.bitDepth, getBitDepthOptions());
             setupEditableCell(index, COL_COLOR_SPACE, info.colorSpace, getColorSpaceOptions());
         }
+
+        // Refresh Output Format options and Film Grain visibility immediately after this file is analyzed
+        updateContainerFormats();
+        onFormatChanged();
     }
     
     // Check if all analysis is complete
@@ -589,6 +596,10 @@ void MainWindow::onMediaAnalysisFinished(int index, const MediaInfo &info)
     if (completedAnalysis >= m_files.size()) {
         logMessage("Media analysis completed", LogLevel::Info);
         completedAnalysis = 0;
+
+        // After all analysis is done, refresh container formats and film grain visibility immediately
+        updateContainerFormats();
+        onFormatChanged();
     }
 }
 


### PR DESCRIPTION
Fixes AV1 film grain application, resolves UI update delays, and refactors `MediaAnalyzer.cpp` for code reuse.

The AV1 film grain re-encoding now correctly uses `libsvtav1` with CRF 20 and preset 4, as specified. UI dropdowns for output format and film grain visibility now refresh immediately after media analysis, ensuring settings are applied and displayed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a733d05-2288-4ab0-a594-61485454635d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a733d05-2288-4ab0-a594-61485454635d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

